### PR TITLE
Correct server latency sorting & start button animation

### DIFF
--- a/app/(game)/Game.tsx
+++ b/app/(game)/Game.tsx
@@ -104,11 +104,14 @@ export default function Game() {
           duration: INIT_ANIMATION_DURATION_MS,
         });
 
+        initTimeline.add({
+          targets: ".init-progress",
+          value: data.percent,
+        });
+
+        if (data.percent < 100) return;
+
         initTimeline
-          .add({
-            targets: ".init-progress",
-            value: data.percent,
-          })
           /* Matches the wrapper and the progress bar to the start button size */
           .add({
             targets: [".animation-wrapper", ".init-progress"],

--- a/libs/Socket.ts
+++ b/libs/Socket.ts
@@ -66,8 +66,6 @@ export class GameSocket extends EventEmitter {
           currentServer.socket.onmessage = ({ data }: MessageEvent) => {
             const message = JSON.parse(data);
 
-            this.emit("message", message);
-
             switch (message.op) {
               case Opcodes.OPEN: {
                 const pingInterval = setInterval(() => {
@@ -113,6 +111,9 @@ export class GameSocket extends EventEmitter {
 
                 break;
               }
+
+              default:
+                this.emit("message", message);
             }
           };
         });


### PR DESCRIPTION
This PR fixes a few issues: 

TBS-127: Due to a mistake in the current implementation, servers are not sorted properly. In the sorting stage, every server has an average latency of 0 and therefore, the socket picks a random server and not the server with the best latency. 

TBS-128: Currently, there are unnecessary animation frames for the start button when the progress bar is still loading. The start animation should only be added to the timeline after the progress bar reaches the end.

I also reduced the default ping interval in this PR, which should speeds up the intial page load.

