### PR TITLE
Improve line clear animation

### DIFF
--- a/app/(game)/(components)/ClearedBlock.tsx
+++ b/app/(game)/(components)/ClearedBlock.tsx
@@ -100,7 +100,16 @@ export default function ClearedBlock({
   );
 
   useTick((delta, ticker) => {
-    if (time.current > MAX_ANIMATION_DURATION_S) return;
+    if (time.current > MAX_ANIMATION_DURATION_S) {
+      /* Resets and ensures the sprite is hidden until it's detached */
+      setSpriteProperties({
+        alpha: 0,
+        position: [initialXDisplacement, initialYDisplacement],
+        scale: 1,
+      });
+
+      return;
+    }
 
     /* Tracks the current animation progress */
     progress.current = parseFloat(
@@ -116,7 +125,7 @@ export default function ClearedBlock({
     const currentYPosition = initialYDisplacement - verticalDisplacement;
 
     setSpriteProperties({
-      alpha: progress.current > 1 ? 0 : 1 - progress.current,
+      alpha: 1 - progress.current,
       position: [currentXPosition, currentYPosition],
       scale: 1 + progress.current * maxScale,
     });

--- a/app/(game)/(components)/Game.tsx
+++ b/app/(game)/(components)/Game.tsx
@@ -28,6 +28,7 @@ type GameProps = {
   setPerformanceInfo: (info: { fps: number; frameTime: number }) => void;
 };
 
+const MAX_CLEARED_BLOCKS = 200;
 const SCREEN_SHAKE_INTERVAL_MS = 10;
 const SCREEN_SHAKE_OFFSETS: [number, number][] = [
   [0, 0],
@@ -60,7 +61,7 @@ export default function Game({
       const timestamp = Date.now();
 
       gameStates.clearRecordsArr.forEach(({ idx: rowIndex, lineTypeArr }) => {
-        const newClearedBlocks = lineTypeArr.map((type, colIndex) => (
+        const nextClearedBlocks = lineTypeArr.map((type, colIndex) => (
           <ClearedBlock
             type={type}
             initialXDisplacement={GAME_PANEL.X + GAME_PANEL.CHILD * colIndex}
@@ -69,10 +70,17 @@ export default function Game({
           />
         ));
 
-        setClearedBlocks((clearedBlocks) => [
-          ...clearedBlocks,
-          ...newClearedBlocks,
-        ]);
+        setClearedBlocks((clearedBlocks) => {
+          const newClearedBlocks = clearedBlocks.concat(nextClearedBlocks);
+
+          /* Detaches older blocks if max cleared blocks is reached */
+          return newClearedBlocks.length > MAX_CLEARED_BLOCKS
+            ? newClearedBlocks.splice(
+                newClearedBlocks.length - MAX_CLEARED_BLOCKS,
+                MAX_CLEARED_BLOCKS
+              )
+            : newClearedBlocks;
+        });
       });
 
       if (!gameOptions.screenShake) return;


### PR DESCRIPTION
This PR includes a fix for sprites of cleared blocks are not discarded throughout the duration of the game, causing visual artifacts on the UI and degraded performance (TBS-135). It also adds rotations to the line clear animation (TBS-136).